### PR TITLE
feat: implement useLaravelCrudResource composable for CRUD operations

### DIFF
--- a/src/runtime/composables/useLaravelCrudResource.ts
+++ b/src/runtime/composables/useLaravelCrudResource.ts
@@ -1,0 +1,151 @@
+import type { LaravelGetOptions, LaravelIndexOptions } from '../types'
+import { useLaravelIndex } from './useLaravelIndex'
+import { useLaravelGet } from './useLaravelGet'
+import { useLaravelForm } from './useLaravelForm'
+import { ZodObject, ZodRawShape } from 'zod'
+
+type CrudOperation = 'create' | 'update' | 'delete' | 'show' | 'index'
+
+type CrudOperationConfig<TForm> = {
+    endpoint?: string
+    schema?: ZodObject<ZodRawShape>
+    initialValues?: TForm
+    onSuccess?: () => void
+    onError?: (error: any) => void
+}
+
+type ShowConfig = {
+    endpoint?: string
+    options?: LaravelGetOptions
+}
+
+type IndexConfig = {
+    endpoint?: string
+    options?: LaravelIndexOptions
+}
+
+type CrudResourceConfig<TCreateForm, TUpdateForm, TDeleteForm> = {
+    config: CrudOperationConfig<TCreateForm>
+    create?: CrudOperationConfig<TCreateForm>
+    update?: CrudOperationConfig<TUpdateForm>
+    delete?: CrudOperationConfig<TDeleteForm>
+    show?: ShowConfig
+    index?: IndexConfig
+    methods?: {
+        [key: string]: (...args: any[]) => any
+    }
+}
+
+export function useLaravelCrudResource<
+    TModel extends Record<string, any>,
+    TCreateForm extends Record<string, any>,
+    TUpdateForm extends Record<string, any> = TCreateForm,
+    TDeleteForm extends Record<string, any> = null
+>(config: CrudResourceConfig<TCreateForm, TUpdateForm, TDeleteForm>) {
+    const buildEndpoint = (
+        operation: CrudOperation,
+        id?: string | number
+    ): string => {
+        const operationConfig = config[operation] as
+            | CrudOperationConfig<any>
+            | undefined
+
+        if (operationConfig?.endpoint) {
+            if (id) {
+                return operationConfig.endpoint.replace(':id', String(id))
+            }
+            return operationConfig.endpoint
+        }
+
+        if (!config.config.endpoint) {
+            throw new Error(
+                `No endpoint configured for ${operation} and no default endpoint in config`
+            )
+        }
+
+        const baseEndpoint = config.config.endpoint
+        if (['update', 'show', 'delete'].includes(operation)) {
+            return `${baseEndpoint}/${id}`
+        }
+        return baseEndpoint
+    }
+
+    const show = async (id: string, options?: LaravelGetOptions) => {
+        const showOptions = options ?? config.show?.options
+        return useLaravelGet<TModel>(buildEndpoint('show', id), showOptions)
+    }
+
+    const index = (options?: LaravelIndexOptions) => {
+        const indexOptions = options ?? config.index?.options
+        return useLaravelIndex<TModel>(buildEndpoint('index'), indexOptions)
+    }
+
+    const getOperationConfig = <TForm>(operation: CrudOperation, id?: any) => {
+        const operationConfig = config[operation] as
+            | CrudOperationConfig<TForm>
+            | undefined
+
+        return {
+            endpoint: buildEndpoint(operation, id),
+            schema: operationConfig?.schema ?? config.config.schema,
+            initialValues:
+                operationConfig?.initialValues ?? config.config.initialValues,
+            onSuccess: operationConfig?.onSuccess ?? config.config.onSuccess,
+            onError: operationConfig?.onError ?? config.config.onError,
+        }
+    }
+    const create = () => {
+        const { endpoint, schema, initialValues, onSuccess, onError } =
+            getOperationConfig<TCreateForm>('create')
+
+        return useLaravelForm<TCreateForm>({
+            initialValues,
+            submitUrl: endpoint,
+            schema: schema,
+            method: 'POST',
+            onSubmitSuccess: onSuccess,
+            onSubmitError: onError,
+        })
+    }
+
+    const update = (model: TUpdateForm & { id: string | number }) => {
+        const { endpoint, schema, onSuccess, onError } =
+            getOperationConfig<TUpdateForm>('update', model.id)
+
+        return useLaravelForm<TUpdateForm>({
+            initialValues: model,
+            submitUrl: endpoint,
+            schema: schema,
+            method: 'PUT',
+            onSubmitSuccess: onSuccess,
+            onSubmitError: onError,
+        })
+    }
+
+    const destroy = (id: string | number) => {
+        const operationConfig = config.delete
+        const endpoint = buildEndpoint('delete', id)
+
+        return useLaravelForm<TDeleteForm>({
+            initialValues:
+                operationConfig?.initialValues ?? ({} as TDeleteForm),
+            submitUrl: endpoint,
+            method: 'DELETE',
+            schema: operationConfig?.schema,
+            onSubmitSuccess:
+                operationConfig?.onSuccess ?? config.config.onSuccess,
+            onSubmitError: operationConfig?.onError ?? config.config.onError,
+        })
+    }
+
+    return {
+        show,
+        index,
+        create,
+        update,
+        destroy,
+        ...config.methods,
+    }
+}
+
+export default useLaravelCrudResource


### PR DESCRIPTION
## Add `useLaravelCrudResource` Composable

## Summary
This PR introduces a new `useLaravelCrudResource` composable that provides a bit more flexibility approach to handling CRUD operations and enhanced type-safe support for different form types. For compatibility reasons I left the old `useLaravelCrud` unchanged and introduced a new composable instead.

## Key Improvements

### 1. **Enhanced Type Safety**
- **Before**: Single generic form type for all operations
- **After**: Separate generic types for create, update, and delete operations
```typescript
useLaravelCrudResource<User, CreateUserForm, UpdateUserForm, DeleteUserForm>()
```

### 2. **Flexible Configuration System**
- **Before**: Single configuration object with limited customization
- **After**: Operation-specific configurations with fallback to global config
```typescript
// Flexible configuration
useLaravelCrudResource({
    config: {
        endpoint: '/api/users',
        schema: userSchema,
        onSuccess: () => console.log('Success!')
    },
    create: {
        endpoint: '/api/users/create', // Override for create only
        schema: createUserSchema,
        onSuccess: () => navigateTo('/users')
    },
    update: {
        schema: updateUserSchema, // Different schema for updates
    }
})
```

### 3. **Improved Endpoint Management**
- **Before**: Manual endpoint construction with optional overrides
- **After**: Intelligent endpoint building with `:id` placeholder support
```typescript
// Supports dynamic endpoints
create: {
    endpoint: '/api/organizations/:id/users'
}
```

### 4. **Better Error Handling**
- **Before**: Limited error handling per operation
- **After**: Operation-specific error handlers with global fallback

### 5. **Extensible Method Support**
- **Before**: Fixed set of CRUD methods
- **After**: Support for custom methods via `methods` configuration

## Usage Example

```typescript
const userCrud = useLaravelCrudResource<User, CreateUserForm, UpdateUserForm>({
    config: {
        endpoint: '/api/users',
        schema: userSchema,
        onSuccess: () => console.log('Operation successful'),
        onError: (error) => console.error('Operation failed:', error)
    },
    create: {
        initialValues: { name: '', email: '' },
        onSuccess: () => navigateTo('/users')
    },
    update: {
        schema: updateUserSchema, // Different validation for updates
    },
    show: {
        options: { with: ['roles', 'permissions'] }
    },
    index: {
        options: { per_page: 25, sort: 'created_at' }
    },
    methods: {
        // Custom methods
        activate: (id: number) => $fetch(`/api/users/${id}/activate`, { method: 'POST' })
    }
})

// Usage
const { data: users } = userCrud.index()
const { data: user } = await userCrud.show(1)
const createForm = userCrud.create()
const updateForm = userCrud.update(existingUser)
const deleteForm = userCrud.destroy(userId)
```

