### PR TITLE
Crud Resource Url-Prefix

### DIFF
--- a/playground/composables/useTest.ts
+++ b/playground/composables/useTest.ts
@@ -18,7 +18,7 @@ export const useTest = useLaravelCrudResource<
     UpdateTestForm
 >({
     config: {
-        endpoint: '/api/tests',
+        endpoint: '/tests',
         initialValues: {
             foo: 'Initial Foo Value',
         },
@@ -27,7 +27,6 @@ export const useTest = useLaravelCrudResource<
         }),
     },
     create: {
-        endpoint: '/api/tests/create',
         initialValues: {
             foo: 'Create Foo Value',
         },
@@ -36,7 +35,6 @@ export const useTest = useLaravelCrudResource<
         }),
     },
     update: {
-        endpoint: '/api/tests/update',
         initialValues: {
             bar: 'Update Bar Value',
         },
@@ -45,7 +43,7 @@ export const useTest = useLaravelCrudResource<
         }),
     },
     show: {
-        endpoint: '/api/tests/show',
+        endpoint: 'bar/baz/:id/boom',
     },
     index: {
         endpoint: '/api/tests/index',

--- a/playground/composables/useTest.ts
+++ b/playground/composables/useTest.ts
@@ -1,0 +1,53 @@
+import * as z from 'zod'
+
+type Test = {
+    foo: string
+}
+
+type CreateTestForm = {
+    foo: string
+}
+
+type UpdateTestForm = {
+    bar: string
+}
+
+export const useTest = useLaravelCrudResource<
+    Test,
+    CreateTestForm,
+    UpdateTestForm
+>({
+    config: {
+        endpoint: '/api/tests',
+        initialValues: {
+            foo: 'Initial Foo Value',
+        },
+        schema: z.object({
+            foo: z.string().min(1, 'Foo is required'),
+        }),
+    },
+    create: {
+        endpoint: '/api/tests/create',
+        initialValues: {
+            foo: 'Create Foo Value',
+        },
+        schema: z.object({
+            foo: z.string().min(1, 'Foo is required'),
+        }),
+    },
+    update: {
+        endpoint: '/api/tests/update',
+        initialValues: {
+            bar: 'Update Bar Value',
+        },
+        schema: z.object({
+            bar: z.string().min(1, 'Bar is required'),
+        }),
+    },
+    show: {
+        endpoint: '/api/tests/show',
+    },
+    index: {
+        endpoint: '/api/tests/index',
+    },
+})

--- a/playground/pages/test.vue
+++ b/playground/pages/test.vue
@@ -7,7 +7,6 @@
 </template>
 
 <script setup lang="ts">
-
 const { index } = useTest
 const { items, load } =
     index({

--- a/playground/pages/test.vue
+++ b/playground/pages/test.vue
@@ -2,12 +2,13 @@
     <div>
         <h1>Test Page</h1>
         <p>This is a test page.</p>
+        <pre>{{ data }}</pre>
         <pre>{{ items }}</pre>
     </div>
 </template>
 
 <script setup lang="ts">
-const { index } = useTest
+const { index, show } = useTest
 const { items, load } =
     index({
         syncUrl: true,
@@ -15,7 +16,12 @@ const { items, load } =
         urlPrefix: '/api/tests/123',
     })
 
+const { data, refresh } = await show('abc', {
+    // urlPrefix: '/api/foo/1',
+})
+
 onMounted(() => {
     load()
+    refresh()
 })
 </script>

--- a/playground/pages/test.vue
+++ b/playground/pages/test.vue
@@ -1,0 +1,22 @@
+<template>
+    <div>
+        <h1>Test Page</h1>
+        <p>This is a test page.</p>
+        <pre>{{ items }}</pre>
+    </div>
+</template>
+
+<script setup lang="ts">
+
+const { index } = useTest
+const { items, load } =
+    index({
+        syncUrl: true,
+    }, {
+        urlPrefix: '/api/tests/123',
+    })
+
+onMounted(() => {
+    load()
+})
+</script>

--- a/src/runtime/composables/useLaravelCrudResource.ts
+++ b/src/runtime/composables/useLaravelCrudResource.ts
@@ -70,35 +70,35 @@ export function useLaravelCrudResource<
     TDeleteForm extends Record<string, any> | null = null
 >(config: CrudResourceConfig<TCreateForm, TUpdateForm, TDeleteForm>) {
     const buildEndpoint = (params: BuildEndpointParams): string => {
-        const operationConfig = config[params.operation] as
+        const { operation, id, urlPrefix } = params
+
+        const operationConfig = config[operation] as
             | CrudOperationConfig<any>
             | undefined
 
-        if (params.urlPrefix) {
-            return `${params.urlPrefix}/${
-                operationConfig?.endpoint ?? ''
-            }`.replace(/\/+/g, '/')
+        if (urlPrefix) {
+            return `${urlPrefix}/${operationConfig?.endpoint ?? ''}`.replace(
+                /\/+/g,
+                '/'
+            )
         }
 
         if (operationConfig?.endpoint) {
-            if (params.id) {
-                return operationConfig.endpoint.replace(
-                    ':id',
-                    String(params.id)
-                )
+            if (id) {
+                return operationConfig.endpoint.replace(':id', String(id))
             }
             return operationConfig.endpoint
         }
 
         if (!config.config.endpoint) {
             throw new Error(
-                `No endpoint configured for ${params.operation} and no default endpoint in config`
+                `No endpoint configured for ${operation} and no default endpoint in config`
             )
         }
 
         const baseEndpoint = config.config.endpoint
-        if (['update', 'show', 'delete'].includes(params.operation)) {
-            return `${baseEndpoint}/${params.id}`
+        if (['update', 'show', 'delete'].includes(operation)) {
+            return `${baseEndpoint}/${id}`
         }
         return baseEndpoint
     }

--- a/src/runtime/composables/useLaravelCrudResource.ts
+++ b/src/runtime/composables/useLaravelCrudResource.ts
@@ -59,6 +59,14 @@ type CrudCreateParams = {
     urlPrefix?: string
 }
 
+type CrudUpdateParams = {
+    urlPrefix?: string
+}
+
+type CrudDeleteParams = {
+    urlPrefix?: string
+}
+
 export function useLaravelCrudResource<
     TModel extends Record<string, any>,
     TCreateForm extends Record<string, any>,
@@ -168,10 +176,14 @@ export function useLaravelCrudResource<
         })
     }
 
-    const update = (model: TUpdateForm & { id: string | number }) => {
+    const update = (
+        model: TUpdateForm & { id: string | number },
+        params?: CrudUpdateParams
+    ) => {
         const { endpoint, schema, onSuccess, onError } =
             getOperationConfig<TUpdateForm>('update', {
                 id: model.id,
+                urlPrefix: params?.urlPrefix,
             })
 
         return useLaravelForm<TUpdateForm>({
@@ -184,10 +196,11 @@ export function useLaravelCrudResource<
         })
     }
 
-    const destroy = (id: string | number) => {
+    const destroy = (id: string | number, params?: CrudDeleteParams) => {
         const operationConfig = config.delete
         const endpoint = buildEndpoint('delete', {
             id,
+            urlPrefix: params?.urlPrefix,
         })
 
         // @ts-expect-error: TDeleteForm can be null, but we need to ensure it is a Record<string, any> for useLaravelForm

--- a/src/runtime/composables/useLaravelForm.ts
+++ b/src/runtime/composables/useLaravelForm.ts
@@ -34,7 +34,7 @@ export function useLaravelForm<TForm extends Record<string, any>>(
         onSubmitError,
     } = options
 
-    const formSchema = toTypedSchema(schema)
+    const formSchema = schema ? toTypedSchema(schema) : undefined
 
     const form = useForm({
         name: `${submitUrl}__${method.toLowerCase()}`,

--- a/src/runtime/types/index.ts
+++ b/src/runtime/types/index.ts
@@ -122,7 +122,7 @@ export type CrudParams<TForm> = {
 export type LaravelFormOptions<TForm extends Record<string, any>> = {
     initialValues: TForm
     submitUrl: string
-    schema: ZodObject<ZodRawShape>
+    schema: ZodObject<ZodRawShape> | undefined
     method?: 'POST' | 'PUT' | 'PATCH' | 'DELETE'
     onSubmitSuccess?: (response: any) => void
     onSubmitError?: (error: any) => void


### PR DESCRIPTION
This pull request refactors the `useLaravelCrudResource` composable to improve parameter handling and introduces type safety enhancements. It also updates related composables and types to align with these changes.

### Refactoring and Type Safety Enhancements:

* **Parameter Handling in `useLaravelCrudResource`:**
  - Replaced individual parameters with structured parameter objects (`BuildEndpointParams`, `GetOperationConfigParams`, `CrudIndexParams`, `CrudShowParams`, `CrudCreateParams`) for better readability and maintainability.
  - Updated methods (`index`, `show`, `create`, `update`, `destroy`) to use the new parameter objects, ensuring consistent parameter passing. [[1]](diffhunk://#diff-fd81cf9650b4204d8b36538e2096c7a9d7d0e503b23dbbf020bae53fd0e6065dR39-R154) [[2]](diffhunk://#diff-fd81cf9650b4204d8b36538e2096c7a9d7d0e503b23dbbf020bae53fd0e6065dL113-R168) [[3]](diffhunk://#diff-fd81cf9650b4204d8b36538e2096c7a9d7d0e503b23dbbf020bae53fd0e6065dL127-R187)

* **Schema Handling in `useLaravelForm`:**
  - Modified schema handling to allow `undefined` values, improving compatibility when no schema is provided.

### Type Updates:

* **LaravelFormOptions Type Adjustment:**
  - Updated the `schema` property in `LaravelFormOptions` to accept `undefined` values, aligning with the changes in `useLaravelForm`.