### PR TITLE
CrudFormTypes, CrudReturnTypes

### DIFF
--- a/playground/composables/useTest.ts
+++ b/playground/composables/useTest.ts
@@ -4,6 +4,10 @@ type Test = {
     foo: string
 }
 
+type Foo = {
+    bar: string
+}
+
 type CreateTestForm = {
     foo: string
 }
@@ -15,7 +19,12 @@ type UpdateTestForm = {
 export const useTest = useLaravelCrudResource<
     Test,
     CreateTestForm,
-    UpdateTestForm
+    UpdateTestForm,
+    null,
+    {
+        index: Foo
+        show: Foo
+    }
 >({
     config: {
         endpoint: '/tests',

--- a/playground/composables/useTest.ts
+++ b/playground/composables/useTest.ts
@@ -1,10 +1,10 @@
 import * as z from 'zod'
 
-type Test = {
+type TestIndexResource = {
     foo: string
 }
 
-type Foo = {
+type TestShowResource = {
     bar: string
 }
 
@@ -22,8 +22,8 @@ type DeleteTestForm = {
 
 export const useTest = useLaravelCrudResource<
     {
-        index: Test
-        show: Foo
+        index: TestIndexResource
+        show: TestShowResource
     },
     {
         create: CreateTestForm

--- a/playground/composables/useTest.ts
+++ b/playground/composables/useTest.ts
@@ -16,14 +16,19 @@ type UpdateTestForm = {
     bar: string
 }
 
+type DeleteTestForm = {
+    baz: string
+}
+
 export const useTest = useLaravelCrudResource<
-    Test,
-    CreateTestForm,
-    UpdateTestForm,
-    null,
     {
-        index: Foo
+        index: Test
         show: Foo
+    },
+    {
+        create: CreateTestForm
+        update: UpdateTestForm
+        delete: DeleteTestForm
     }
 >({
     config: {

--- a/playground/pages/test.vue
+++ b/playground/pages/test.vue
@@ -2,7 +2,7 @@
     <div>
         <h1>Test Page</h1>
         <p>This is a test page.</p>
-        <pre>{{ data }}</pre>
+        <pre>{{ data?.bar }}</pre>
         <pre>{{ items }}</pre>
     </div>
 </template>

--- a/src/runtime/composables/useLaravelCrudResource.ts
+++ b/src/runtime/composables/useLaravelCrudResource.ts
@@ -28,11 +28,70 @@ type IndexConfig = {
     options?: LaravelIndexOptions
 }
 
-type CrudResourceConfig<TCreateForm, TUpdateForm, TDeleteForm> = {
-    config: CrudOperationConfig<TCreateForm>
-    create?: CrudOperationConfig<TCreateForm>
-    update?: CrudOperationConfig<TUpdateForm>
-    delete?: CrudOperationConfig<TDeleteForm>
+type WithUrlPrefix = {
+    urlPrefix?: string
+}
+
+type BuildEndpointParams = WithUrlPrefix & {
+    id?: string | number
+}
+
+type GetOperationConfigParams = WithUrlPrefix & {
+    id?: string | number
+}
+
+type CrudIndexParams = WithUrlPrefix
+
+type CrudCreateParams = WithUrlPrefix
+
+type CrudUpdateParams = WithUrlPrefix
+
+type CrudDeleteParams = WithUrlPrefix
+
+type CrudShowParams = WithUrlPrefix & {
+    options?: LaravelGetOptions
+}
+
+type CrudFormTypes<
+    TCreate extends Record<string, any>,
+    TUpdate = TCreate,
+    TDelete = object
+> = {
+    create: TCreate
+    update?: TUpdate
+    delete?: TDelete
+}
+
+type CrudReturnTypes<
+    TIndexModel,
+    TShow = TIndexModel,
+    TUpdate = TIndexModel
+> = {
+    index: TIndexModel
+    show?: TShow
+    update?: TUpdate
+}
+
+type ExtractFormType<
+    TForms,
+    K extends keyof CrudFormTypes<any, any, any>,
+    TCreateFallback
+> = K extends keyof TForms
+    ? NonNullable<TForms[K]> extends Record<string, any>
+        ? NonNullable<TForms[K]>
+        : object
+    : TCreateFallback
+
+type ExtractReturnType<
+    TReturns extends { index: any },
+    K extends keyof any
+> = K extends keyof TReturns ? NonNullable<TReturns[K]> : TReturns['index']
+
+type CrudResourceConfig<TCreate, TUpdate, TDelete> = {
+    config: CrudOperationConfig<TCreate>
+    create?: CrudOperationConfig<TCreate>
+    update?: CrudOperationConfig<TUpdate>
+    delete?: CrudOperationConfig<TDelete>
     show?: ShowConfig
     index?: IndexConfig
     methods?: {
@@ -40,61 +99,23 @@ type CrudResourceConfig<TCreateForm, TUpdateForm, TDeleteForm> = {
     }
 }
 
-type BuildEndpointParams = {
-    id?: string | number
-    urlPrefix?: string
-}
-
-type GetOperationConfigParams = {
-    id?: string | number
-    urlPrefix?: string
-}
-
-type CrudIndexParams = {
-    urlPrefix?: string
-}
-
-type CrudShowParams = {
-    options?: LaravelGetOptions
-    urlPrefix?: string
-}
-
-type CrudCreateParams = {
-    urlPrefix?: string
-}
-
-type CrudUpdateParams = {
-    urlPrefix?: string
-}
-
-type CrudDeleteParams = {
-    urlPrefix?: string
-}
-
-type CrudReturnOverrides = {
-    index?: any
-    show?: any
-}
-
-type IndexModelOverride<TOverrides, TModel> = TOverrides extends {
-    index: infer U
-}
-    ? U
-    : TModel
-
-type ShowModelOverride<TOverrides, TModel> = TOverrides extends {
-    show: infer U
-}
-    ? U
-    : TModel
-
 export function useLaravelCrudResource<
-    TModel extends Record<string, any>,
-    TCreateForm extends Record<string, any>,
-    TUpdateForm extends Record<string, any> = TCreateForm,
-    TDeleteForm extends Record<string, any> | null = null,
-    TOverrides extends Partial<CrudReturnOverrides> = object
->(config: CrudResourceConfig<TCreateForm, TUpdateForm, TDeleteForm>) {
+    TReturns extends CrudReturnTypes<any>,
+    TForms extends CrudFormTypes<any>
+>(
+    config: CrudResourceConfig<
+        TForms['create'],
+        ExtractFormType<TForms, 'update', TForms['create']>,
+        ExtractFormType<TForms, 'delete', null>
+    >
+) {
+    type TModel = TReturns['index']
+    type TCreateForm = TForms['create']
+    type TUpdateForm = ExtractFormType<TForms, 'update', TCreateForm>
+    type TDeleteForm = ExtractFormType<TForms, 'delete', null>
+
+    type TShowModel = ExtractReturnType<TReturns, 'show'>
+
     const buildEndpoint = (
         operation: CrudOperation,
         params: BuildEndpointParams
@@ -161,15 +182,12 @@ export function useLaravelCrudResource<
         }
     }
 
-    type IndexModel = IndexModelOverride<TOverrides, TModel>
-    type IndexReturnType = LaravelIndex<IndexModel>
-
     const index = (
         options?: LaravelIndexOptions,
         params?: CrudIndexParams
-    ): IndexReturnType => {
+    ): LaravelIndex<TModel> => {
         const indexOptions = options ?? config.index?.options
-        return useLaravelIndex<IndexModel>(
+        return useLaravelIndex<TModel>(
             buildEndpoint('index', {
                 urlPrefix: params?.urlPrefix,
             }),
@@ -177,11 +195,9 @@ export function useLaravelCrudResource<
         )
     }
 
-    type ShowModel = ShowModelOverride<TOverrides, TModel>
-
     const show = async (id: string | number, params?: CrudShowParams) => {
         const showOptions = params?.options ?? config.show?.options
-        return useLaravelGet<ShowModel>(
+        return useLaravelGet<TShowModel>(
             buildEndpoint('show', {
                 id,
                 urlPrefix: params?.urlPrefix,
@@ -233,10 +249,11 @@ export function useLaravelCrudResource<
             urlPrefix: params?.urlPrefix,
         })
 
-        // @ts-expect-error: TDeleteForm can be null, but we need to ensure it is a Record<string, any> for useLaravelForm
+        // @ts-expect-error: Type 'TDeleteForm' is not assignable to type 'Record<string, any>'.
         return useLaravelForm<TDeleteForm>({
             initialValues:
-                operationConfig?.initialValues ?? ({} as TDeleteForm),
+                operationConfig?.initialValues ??
+                ({} as unknown as TDeleteForm),
             submitUrl: endpoint,
             method: 'DELETE',
             schema: operationConfig?.schema,

--- a/src/runtime/composables/useLaravelIndex.ts
+++ b/src/runtime/composables/useLaravelIndex.ts
@@ -11,7 +11,6 @@ import type {
 } from '../types'
 import { prepareQueryParams } from '../utils/prepareQueryParams'
 import { useLaravelApi } from './useLaravelApi'
-import { th } from 'zod/v4/locales'
 
 export function useLaravelIndex<T extends object>(
     endpoint: string,

--- a/src/runtime/composables/useLaravelIndex.ts
+++ b/src/runtime/composables/useLaravelIndex.ts
@@ -11,6 +11,7 @@ import type {
 } from '../types'
 import { prepareQueryParams } from '../utils/prepareQueryParams'
 import { useLaravelApi } from './useLaravelApi'
+import { th } from 'zod/v4/locales'
 
 export function useLaravelIndex<T extends object>(
     endpoint: string,
@@ -93,6 +94,8 @@ export function useLaravelIndex<T extends object>(
             if (options?.onError) {
                 options.onError(e)
             }
+
+            throw e
         } finally {
             state.value.loading = false
         }

--- a/src/runtime/composables/useLaravelIndex.ts
+++ b/src/runtime/composables/useLaravelIndex.ts
@@ -7,6 +7,7 @@ import type {
     LaravelResponseMeta,
     LaravelIndexOptions,
     LaravelIndexState,
+    LaravelIndex,
 } from '../types'
 import { prepareQueryParams } from '../utils/prepareQueryParams'
 import { useLaravelApi } from './useLaravelApi'
@@ -14,7 +15,7 @@ import { useLaravelApi } from './useLaravelApi'
 export function useLaravelIndex<T extends object>(
     endpoint: string,
     options?: LaravelIndexOptions
-) {
+): LaravelIndex<T> {
     const router = useRouter()
     const route = useRoute()
 
@@ -98,7 +99,7 @@ export function useLaravelIndex<T extends object>(
     }
 
     const hasNextPage = computed(() => {
-        return (
+        return !!(
             state.value.meta &&
             state.value.meta.current_page &&
             state.value.meta.current_page < state.value.meta.last_page
@@ -106,7 +107,7 @@ export function useLaravelIndex<T extends object>(
     })
 
     const hasPrevPage = computed(() => {
-        return (
+        return !!(
             state.value.meta &&
             state.value.meta.current_page &&
             state.value.meta.current_page > 1
@@ -272,16 +273,8 @@ export function useLaravelIndex<T extends object>(
         setConfig(options)
     }
 
-    // load the first page on init
-    // if (state.value.__hash === undefined) {
-    //     stateHash()
-    //     await useAsyncData(`${endpoint}`, async () => {
-    //         return await load()
-    //     })
-    // }
-
     return {
-        ...toRefs(state.value),
+        ...(toRefs(state.value) as any as LaravelIndexState<T>),
         state,
         hasNextPage,
         hasPrevPage,

--- a/src/runtime/types/index.ts
+++ b/src/runtime/types/index.ts
@@ -1,3 +1,4 @@
+import type { Ref } from 'vue'
 import type { ZodObject, ZodRawShape } from 'zod'
 
 export type LaravelResponseMeta = {
@@ -48,6 +49,25 @@ export type LaravelIndexOptions = {
     ssr?: boolean
     onError?: (error: any) => void
     onSuccess?: (response: IndexResponse<any>) => void
+}
+
+export type LaravelIndex<T> = LaravelIndexState<T> & {
+    state: Ref<LaravelIndexState<T>>
+    hasNextPage: Ref<boolean>
+    hasPrevPage: Ref<boolean>
+    nextPage: () => void
+    prevPage: () => void
+    setPerPage: (perPage: number) => void
+    setPage: (page: number) => void
+    setSearch: (search: string) => void
+    setFilter: (filter: Filter) => void
+    setSort: (sort: string) => void
+    setSyncUrl: (syncUrl: boolean) => void
+    setConfig: (config: LaravelIndexOptions) => void
+    load: (page?: number, append?: boolean) => Promise<void>
+    loadAll: () => Promise<void>
+    loadMore: () => void
+    mutateStateItem: (id: string | number, data: Partial<T>) => void
 }
 
 export type FilterOperatorOption =


### PR DESCRIPTION
This pull request introduces several enhancements and refactorings to the Laravel CRUD composables in the codebase. The changes improve type definitions, streamline CRUD operations, and enhance the functionality of the `useLaravelIndex` composable.

<img width="401" height="653" alt="Bildschirmfoto 2025-07-23 um 15 52 57" src="https://github.com/user-attachments/assets/ea67ec23-dc74-4ce1-97f2-5958bba3a81a" />



### Type Enhancements and Refactorings:
- **Refactored `CrudResourceConfig` and related types**: Introduced `CrudFormTypes` and `CrudReturnTypes` to simplify type definitions for CRUD operations. Added helper types like `ExtractFormType` and `ExtractReturnType` to improve type inference and flexibility. [[1]](diffhunk://#diff-fd81cf9650b4204d8b36538e2096c7a9d7d0e503b23dbbf020bae53fd0e6065dL27-R118) [[2]](diffhunk://#diff-fd81cf9650b4204d8b36538e2096c7a9d7d0e503b23dbbf020bae53fd0e6065dL206-R256)
- **Enhanced `LaravelIndex` type**: Added a comprehensive definition for `LaravelIndex` that includes state management and utility methods such as `nextPage`, `prevPage`, `setSearch`, and `load`.

### Functionality Improvements:
- **Updated `useLaravelIndex` composable**: Refactored return type to use the new `LaravelIndex` type, improving clarity and functionality. Removed commented-out initialization logic for better maintainability. [[1]](diffhunk://#diff-69763dbc30b4d19d007129585f5876d272c2ae6abd309b76fe877b284c9f2c8cR10-R18) [[2]](diffhunk://#diff-69763dbc30b4d19d007129585f5876d272c2ae6abd309b76fe877b284c9f2c8cL275-R277)
- **Improved `useLaravelCrudResource` composable**: Refactored CRUD operation methods (`index`, `show`, etc.) to leverage new type definitions, ensuring better type safety and extensibility. [[1]](diffhunk://#diff-fd81cf9650b4204d8b36538e2096c7a9d7d0e503b23dbbf020bae53fd0e6065dL142-R188) [[2]](diffhunk://#diff-fd81cf9650b4204d8b36538e2096c7a9d7d0e503b23dbbf020bae53fd0e6065dL154-R200)

### Minor Updates:
- **Added optional chaining in `test.vue`**: Updated template to use `data?.bar` for safer rendering.
- **Introduced new types in `useTest.ts`**: Added `Foo` and `DeleteTestForm` types to extend CRUD functionality. Updated `useTest` composable configuration accordingly. [[1]](diffhunk://#diff-a53a3e3c53d9f9d220533c7ea7ace301c7ba15ad8c4a14a8fb07531383e78e47R7-R10) [[2]](diffhunk://#diff-a53a3e3c53d9f9d220533c7ea7ace301c7ba15ad8c4a14a8fb07531383e78e47R19-R32)