### PR TITLE
useLaravelApi enhancements

### DIFF
--- a/src/runtime/composables/useLaravelApi.ts
+++ b/src/runtime/composables/useLaravelApi.ts
@@ -24,63 +24,49 @@ export const useLaravelApi = () => {
         return `${apiBase}${url}`
     }
 
-    const get = async (url: string, options: any = {}) => {
+    const makeRequest = async (url: string, options: any = {}) => {
         return await ofetch(getApiUrl(url), {
-            method: 'GET',
             headers: {
                 Accept: 'application/json',
                 'X-XSRF-TOKEN': xsrfToken || '',
             },
             credentials: 'include',
             ...options,
+        })
+    }
+
+    const get = async (url: string, options: any = {}) => {
+        return makeRequest(url, {
+            ...options,
+            method: 'GET',
         })
     }
     const post = async (url: string, body: any, options: any = {}) => {
-        return await ofetch(getApiUrl(url), {
-            method: 'POST',
-            headers: {
-                Accept: 'application/json',
-                'X-XSRF-TOKEN': xsrfToken || '',
-            },
-            body,
-            credentials: 'include',
+        return makeRequest(url, {
             ...options,
+            method: 'POST',
+            body,
         })
     }
     const put = async (url: string, body: any, options: any = {}) => {
-        return await ofetch(getApiUrl(url), {
-            method: 'PUT',
-            headers: {
-                Accept: 'application/json',
-                'X-XSRF-TOKEN': xsrfToken || '',
-            },
-            body,
-            credentials: 'include',
+        return makeRequest(url, {
             ...options,
+            method: 'PUT',
+            body,
         })
     }
     const patch = async (url: string, body: any, options: any = {}) => {
-        return await ofetch(getApiUrl(url), {
-            method: 'PATCH',
-            headers: {
-                Accept: 'application/json',
-                'X-XSRF-TOKEN': xsrfToken || '',
-            },
-            body,
-            credentials: 'include',
+        return makeRequest(url, {
             ...options,
+            method: 'PATCH',
+            body,
         })
     }
     const destroy = async (url: string, body: any, options: any = {}) => {
-        return await ofetch(getApiUrl(url), {
-            method: 'DELETE',
-            headers: {
-                Accept: 'application/json',
-                'X-XSRF-TOKEN': xsrfToken || '',
-            },
-            credentials: 'include',
-            body,
+        return makeRequest(url, {
             ...options,
+            method: 'DELETE',
+            body,
         })
     }
 

--- a/src/runtime/composables/useLaravelApi.ts
+++ b/src/runtime/composables/useLaravelApi.ts
@@ -25,6 +25,8 @@ export const useLaravelApi = () => {
     }
 
     const makeRequest = async (url: string, options: any = {}) => {
+        const xsrfToken = useCookie('XSRF-TOKEN').value
+
         const fetch =
             typeof useNuxtApp().$apiFetch === 'function'
                 ? (useNuxtApp().$apiFetch as typeof ofetch)

--- a/src/runtime/composables/useLaravelApi.ts
+++ b/src/runtime/composables/useLaravelApi.ts
@@ -1,11 +1,9 @@
 import { useCookie, useNuxtApp } from 'nuxt/app'
+import type { ofetch } from 'ofetch'
 import { useLaravelConfig } from '#imports'
-import { ofetch } from 'ofetch'
 
 export const useLaravelApi = () => {
     const config = useLaravelConfig()
-
-    const xsrfToken = useCookie('XSRF-TOKEN').value
 
     const getApiUrl = (url: string): string => {
         if (!url.startsWith('/')) {

--- a/src/runtime/composables/useLaravelApi.ts
+++ b/src/runtime/composables/useLaravelApi.ts
@@ -1,6 +1,6 @@
-import { ofetch } from 'ofetch'
-import { useCookie } from 'nuxt/app'
+import { useCookie, useNuxtApp } from 'nuxt/app'
 import { useLaravelConfig } from '#imports'
+import { ofetch } from 'ofetch'
 
 export const useLaravelApi = () => {
     const config = useLaravelConfig()
@@ -25,7 +25,12 @@ export const useLaravelApi = () => {
     }
 
     const makeRequest = async (url: string, options: any = {}) => {
-        return await ofetch(getApiUrl(url), {
+        const fetch =
+            typeof useNuxtApp().$apiFetch === 'function'
+                ? (useNuxtApp().$apiFetch as typeof ofetch)
+                : ($fetch as typeof ofetch)
+
+        return await fetch(getApiUrl(url), {
             headers: {
                 Accept: 'application/json',
                 'X-XSRF-TOKEN': xsrfToken || '',
@@ -86,6 +91,7 @@ export const useLaravelApi = () => {
         put,
         patch,
         destroy,
+        makeRequest,
         client,
     }
 }


### PR DESCRIPTION
This pull request refactors the `useLaravelApi` composable to improve code reuse and flexibility in handling API requests. The changes include consolidating request logic into a new `makeRequest` function, updating method implementations to use this function, and improving dependency imports.

### Refactoring for code reuse and flexibility:

* Introduced a new `makeRequest` function to centralize API request logic, including handling headers, XSRF tokens, and dynamic fetch methods (`$apiFetch` or `$fetch`). This reduces duplication across HTTP methods like `get`, `post`, `put`, `patch`, and `destroy`. [[1]](diffhunk://#diff-0cff5686c4f0e5a51468b30cd03fb1deed1f45eef861d34d634241361d4458fdL27-R35) [[2]](diffhunk://#diff-0cff5686c4f0e5a51468b30cd03fb1deed1f45eef861d34d634241361d4458fdR44-L83)

* Updated all HTTP method implementations (`get`, `post`, `put`, `patch`, `destroy`) to delegate request handling to the new `makeRequest` function, simplifying their logic and ensuring consistent behavior.

### Dependency improvements:

* Adjusted import statements for better organization, including moving `ofetch` and `useNuxtApp` to the top of the file and grouping imports logically.

### Additional changes:

* Exported the `makeRequest` function alongside other methods, enabling potential reuse outside the composable.